### PR TITLE
Fixed publish workflow to upload bundle instead of apk

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
         run: |
           cd kiwix-android
-          eval "./gradlew publish${TAG^}ReleaseApkWithExpansionFile"
+          eval "./gradlew publish${TAG^}ReleaseBundleWithExpansionFile"


### PR DESCRIPTION
Fixes #78 

Changed command in `publish.yml` to upload `App Bundle` instead of uploading `APK`.