### PR TITLE
Upload apk on play store instead of uploading the app bundle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
         run: |
           cd kiwix-android
-          eval "./gradlew publish${TAG^}ReleaseBundleWithExpansionFile"
+          eval "./gradlew publish${TAG^}ReleaseApkWithExpansionFile"


### PR DESCRIPTION
Fixes #83 

We are now uploading the apk instead of uploading of app bundle on play store. So we have changed `./gradlew publish${TAG^}ReleaseBundleWithExpansionFile` command to `./gradlew publish${TAG^}ReleaseApkWithExpansionFile` .