### PR TITLE
Release workflow only on 'main' branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Publish Custom App
 on:
   release:
     types: [published]
+    branches:
+      - main
 
 jobs:
   publish:


### PR DESCRIPTION
To avoid tags on feature branches or even forks