### PR TITLE
Disables TTS (read aloud) for DWDS custom app

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Retrieving Kiwix Android source code
-        run: git clone --depth=1 --single-branch --branch develop https://github.com/kiwix/kiwix-android.git
+        run: git clone --depth=1 --single-branch --branch Issue#3508 https://github.com/kiwix/kiwix-android.git
 
       - name: Copying custom app configuration into Kiwix Android code base
         run: ./copy_files_to_kiwix_android.sh
@@ -27,7 +27,6 @@ jobs:
         run: |
           echo "$playstore_json" > kiwix-android/playstore.json
           echo "$keystore" | base64 -d > kiwix-android/kiwix-android.keystore
-
       - name: Set tag variable
         run: echo "TAG=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
 
@@ -39,4 +38,4 @@ jobs:
           DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION: ${{ secrets.DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION }}
         run: |
           cd kiwix-android
-          eval "./gradlew publish${TAG^}ReleaseApkWithExpansionFile"
+          eval "./gradlew publish${TAG^}ReleaseBundleWithPlayAssetDelivery"

--- a/dwds/info.json
+++ b/dwds/info.json
@@ -1,5 +1,5 @@
 {
   "app_name": "Dwds",
-  "zim_url": "https://{{DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-09-12.zim",
+  "zim_url": "https://{{DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-10-26.zim",
   "enforced_lang": "de"
 }

--- a/dwds/info.json
+++ b/dwds/info.json
@@ -1,5 +1,6 @@
 {
   "app_name": "Dwds",
   "zim_url": "https://{{DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-10-26.zim",
-  "enforced_lang": "de"
+  "enforced_lang": "de",
+  "disable_read_aloud": true
 }


### PR DESCRIPTION
The results of the builtin text-to-speech service are not good enough at the moment, so we would prefer to disable this feature until we found a way to control which parts of a DWDS article are read and in which order.