### PR TITLE
Added `disable_title` for dwds app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ important fields are:
 - `disable_sidebar`, a boolean value, when set to `true`, it hides the sidebar
 - `disable_tabs`, a boolean value, when set to `true`, it deactivates the multi-tabs feature
 - `disable_read_aloud`, a boolean value, when set to `true`, it disable the text-to-speech feature
+- `disable_title`, a boolean value, when set to `true`, it disable the app title and set the app icon to hamburger
 - `new`, A boolean value, when set to `true`, it triggers the creation
   and storage of a dummy release Bundle during the current workflow
   run.

--- a/dwds/info.json
+++ b/dwds/info.json
@@ -2,5 +2,6 @@
   "app_name": "DWDS",
   "zim_url": "https://{{DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-11-20.zim",
   "enforced_lang": "de",
-  "disable_read_aloud": true
+  "disable_read_aloud": true,
+  "disable_title": true
 }


### PR DESCRIPTION
See https://github.com/kiwix/kiwix-android/issues/3528#issuecomment-1814905330 , https://github.com/kiwix/kiwix-android/issues/3528

* It will hide the app title and set the app icon to hamburger.
* Updated the README.md file to show this new feature introduce for custom apps.