### PR TITLE
Added `disable_external_links` for dwds app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ important fields are:
 - `disable_tabs`, a boolean value, when set to `true`, it deactivates the multi-tabs feature
 - `disable_read_aloud`, a boolean value, when set to `true`, it disable the text-to-speech feature
 - `disable_title`, a boolean value, when set to `true`, it disable the app title and set the app icon to hamburger
+- `disable_external_links`, a boolean value when set to `true`, it disables the external link popup
+  and hides the external links preference from the settings.
 - `new`, A boolean value, when set to `true`, it triggers the creation
   and storage of a dummy release Bundle during the current workflow
   run.

--- a/dwds/info.json
+++ b/dwds/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://{{DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-11-20.zim",
   "enforced_lang": "de",
   "disable_read_aloud": true,
-  "disable_title": true
+  "disable_title": true,
+  "disable_external_links": true
 }


### PR DESCRIPTION
See https://github.com/kiwix/kiwix-android/issues/3586

* it disables the external link popup and hides the external links preference from the settings.
* Updated the `README.md` file to show this new feature introduce for custom apps.