### PR TITLE
Added `about_the_app` for dwds app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ important fields are:
 - `disable_read_aloud`, a boolean value, when set to `true`, it disable the text-to-speech feature
 - `disable_title`, a boolean value, when set to `true`, it disable the app title and set the app icon to hamburger
 - `disable_external_links`, a boolean value when set to `true`, it disables the external link popup
+- `about_the_app`, a URL, when it is set, it adds an `About the app` item to the sidebar. Clicking it opens the URL in an external web browser
   and hides the external links preference from the settings.
 - `new`, A boolean value, when set to `true`, it triggers the creation
   and storage of a dummy release Bundle during the current workflow

--- a/dwds/info.json
+++ b/dwds/info.json
@@ -4,5 +4,6 @@
   "enforced_lang": "de",
   "disable_read_aloud": true,
   "disable_title": true,
-  "disable_external_links": true
+  "disable_external_links": true,
+  "about_app_url": "https://www.dwds.de/d/ueber-uns"
 }


### PR DESCRIPTION
See https://github.com/kiwix/kiwix-android/issues/3590

* It adds an `About the app` item to the sidebar. Clicking it opens the URL in an external web browser
* Updated the `README.md` file to show this new feature introduce for custom apps.