### PR TITLE
Fixed Continuous Deployment fails to create dummy bundle (even if not specified in the info.json)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,10 @@ jobs:
         run: ./copy_files_to_kiwix_android.sh
 
       - name: Install jq
-        run: apt-get install -y jq
+        run: sudo apt-get install -y jq
+
+      - name: Set tag variable
+        run: echo "TAG=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
 
       - name: Should upload dummy Bundle
         run: |
@@ -72,10 +75,6 @@ jobs:
           keystore: ${{ secrets.keystore }}
         run: |
           echo "$keystore" | base64 -d > kiwix-android/kiwix-android.keystore
-
-      - name: Set tag variable
-        if: env.should_publish == 'true'
-        run: echo "TAG=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
 
       - name: Generate dummy Bundle
         if: env.should_publish == 'true'


### PR DESCRIPTION
Fixes #124 
* Fixed permission issues while installing `jq` in CI.
* Updated CI to set the TAG variable earlier, as it is required in the `Should upload dummy Bundle task`.

* When `new` is not defined in the `info.json` file, it skips the uploading of APK without CI failing https://github.com/kiwix/kiwix-android-custom/actions/runs/7221929480/job/19677928731?pr=134
* When `new` is defined in the info.json file, it uploads the APK https://github.com/kiwix/kiwix-android-custom/actions/runs/7222004996/job/19678152206?pr=134