### PR TITLE
Updated the branch name from develop to main in the publish.yml file.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Retrieving Kiwix Android source code
-        run: git clone --depth=1 --single-branch --branch develop https://github.com/kiwix/kiwix-android.git
+        run: git clone --depth=1 --single-branch --branch main https://github.com/kiwix/kiwix-android.git
 
       - name: Copying custom app configuration into Kiwix Android code base
         run: ./copy_files_to_kiwix_android.sh
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Retrieving Kiwix Android source code
-        run: git clone --depth=1 --single-branch --branch develop https://github.com/kiwix/kiwix-android.git
+        run: git clone --depth=1 --single-branch --branch main https://github.com/kiwix/kiwix-android.git
 
       - name: Copying custom app configuration into Kiwix Android code base
         run: ./copy_files_to_kiwix_android.sh


### PR DESCRIPTION
Fixes #135 

* Due to the absence of a `develop` branch in the `kiwix-android` repository, our publishing and bundle uploading tasks will be fail. Consequently, we have modified the branch reference to main since the `kiwix-android` repository now uses `main` instead of `develop`.