### PR TITLE
Removed new key to prevent upload dummy bundle

### DIFF
--- a/afconpedia/info.json
+++ b/afconpedia/info.json
@@ -3,6 +3,5 @@
   "zim_url": "https://drive.farm.openzim.org/custom%20apps/CAN%20App%20-%20English/All%20Articles%20/CANAllArticlesEN-1ed6e94c6348_2024-01.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": false,
-  "new": true
+  "upload_bundle": true
 }

--- a/canpedia/info.json
+++ b/canpedia/info.json
@@ -3,6 +3,5 @@
   "zim_url": "https://drive.farm.openzim.org/custom%20apps/CAN%20App%20-%20French/All%20Articles%20-%20FR/CANAllArticlesFR-4546453e6f9d_2024-01.zim",
   "enforced_lang": "fr",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": false,
-  "new": true
+  "upload_bundle": true
 }


### PR DESCRIPTION
First time we've to set the `new` key to upload dummy bundle in order to set the path for the play store entry. After that we should remove that or set it to false.