### PR TITLE
Using `JAVA_17` in cd.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,13 @@ jobs:
 
     steps:
       - name: Retrieving custom app configuration
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
 
       - name: Retrieving Kiwix Android source code
         run: git clone --depth=1 --single-branch --branch main https://github.com/kiwix/kiwix-android.git
@@ -62,7 +68,13 @@ jobs:
 
     steps:
       - name: Retrieving custom app configuration
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
 
       - name: Retrieving Kiwix Android source code
         run: git clone --depth=1 --single-branch --branch main https://github.com/kiwix/kiwix-android.git


### PR DESCRIPTION
`Kiwix-android` requires the `JAVA_17` to compile so we have refactored our cd to use `JAVA_17`. The default workflow was using the JAVA_11. See https://github.com/kiwix/kiwix-android-custom/actions/runs/10575125316/job/29298159410.