### PR TITLE
Refactored the `cd` according to new feature of ABI splitting of `Kiwix-Android`.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,6 +57,7 @@ jobs:
           if [ "$should_publish_bundle" == 'true' ]; then
             echo "should_publish_bundle=true" >> $GITHUB_ENV
           else
+            echo "APK_BUILD=true" >> $GITHUB_ENV
             echo "should_publish_bundle=false" >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
Fixes #218 

* We have refactored our CD to set the `APK_BUILD` env variable when we upload the APK on Play Store so that ABI splitting will enable for that custom app.