### PR TITLE
Added support to build custom apps from a specific `revision ID`.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,10 +20,13 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
       - name: Read revision ID from info.json
         run: |
           cd ${TAG}
-          rev_id=$(jq -r '.kiwix-android_revision // empty' info.json)
+          rev_id=$(jq -r '."kiwix-android_revision" // empty' info.json)
           if [ -z "$rev_id" ]; then
             echo "REV_ID=" >> $GITHUB_ENV
           else
@@ -48,9 +51,6 @@ jobs:
 
       - name: Set tag variable
         run: echo "TAG=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
-
-      - name: Install jq
-        run: sudo apt-get install -y jq
 
       - name: Set non-kiwix organization tag
         run: |
@@ -108,10 +108,13 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
       - name: Read revision ID from info.json
         run: |
           cd ${TAG}
-          rev_id=$(jq -r '.kiwix-android_revision // empty' info.json)
+          rev_id=$(jq -r '."kiwix-android_revision" // empty' info.json)
           if [ -z "$rev_id" ]; then
             echo "REV_ID=" >> $GITHUB_ENV
           else
@@ -133,9 +136,6 @@ jobs:
 
       - name: Copying custom app configuration into Kiwix Android code base
         run: ./copy_files_to_kiwix_android.sh
-
-      - name: Install jq
-        run: sudo apt-get install -y jq
 
       - name: Set tag variable
         run: echo "TAG=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,28 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      - name: Read revision ID from info.json
+        run: |
+          cd ${TAG}
+          rev_id=$(jq -r '.kiwix-android_revision // empty' info.json)
+          if [ -z "$rev_id" ]; then
+            echo "REV_ID=" >> $GITHUB_ENV
+          else
+            echo "REV_ID=$rev_id" >> $GITHUB_ENV
+          fi
+
       - name: Retrieving Kiwix Android source code
-        run: git clone --depth=1 --single-branch --branch main https://github.com/kiwix/kiwix-android.git
+        run: |
+          if [ -z "${{ env.REV_ID }}" ]; then
+            echo "Cloning latest commit from main branch"
+            git clone --depth=1 --single-branch --branch main https://github.com/kiwix/kiwix-android.git
+          else
+            echo "Cloning specific commit: ${{ env.REV_ID }}"
+            git clone https://github.com/kiwix/kiwix-android.git
+            cd kiwix-android
+            git checkout ${{ env.REV_ID }}
+            cd ..
+          fi
 
       - name: Copying custom app configuration into Kiwix Android code base
         run: ./copy_files_to_kiwix_android.sh
@@ -88,8 +108,28 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      - name: Read revision ID from info.json
+        run: |
+          cd ${TAG}
+          rev_id=$(jq -r '.kiwix-android_revision // empty' info.json)
+          if [ -z "$rev_id" ]; then
+            echo "REV_ID=" >> $GITHUB_ENV
+          else
+            echo "REV_ID=$rev_id" >> $GITHUB_ENV
+          fi
+
       - name: Retrieving Kiwix Android source code
-        run: git clone --depth=1 --single-branch --branch main https://github.com/kiwix/kiwix-android.git
+        run: |
+          if [ -z "${{ env.REV_ID }}" ]; then
+            echo "Cloning latest commit from main branch"
+            git clone --depth=1 --single-branch --branch main https://github.com/kiwix/kiwix-android.git
+          else
+            echo "Cloning specific commit: ${{ env.REV_ID }}"
+            git clone https://github.com/kiwix/kiwix-android.git
+            cd kiwix-android
+            git checkout ${{ env.REV_ID }}
+            cd ..
+          fi
 
       - name: Copying custom app configuration into Kiwix Android code base
         run: ./copy_files_to_kiwix_android.sh

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ important fields are:
   run.
 - `upload_bundle` A boolean value. When set to true, it uploads the bundle to the Play Store,
   Otherwise, it uploads the APK.
+- `kiwix-android_revision` A specific Git commit SHA (revision ID) of the `kiwix-android` repository to use when building the app.
+   - If this field is set to an `empty` string or `latest`, the latest commit from the `main` branch will be used.
+   - If this field contains a valid commit SHA, that specific version of the `kiwix-android` code base will be used for the build.
 
 You can also create this new file using Github IO. Go to
 https://github.com/kiwix/kiwix-android-custom/new/main and type

--- a/afconpedia/info.json
+++ b/afconpedia/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://drive.farm.openzim.org/custom%20apps/CAN%20App%20-%20English/All%20Articles%20/CANAllArticlesEN-1ed6e94c6348_2024-01.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/bollywood/info.json
+++ b/bollywood/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/wikipedia/wikipedia_en_indian_cinema_nopic_2023-12.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/canpedia/info.json
+++ b/canpedia/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://drive.farm.openzim.org/custom%20apps/CAN%20App%20-%20French/All%20Articles%20-%20FR/CANAllArticlesFR-4546453e6f9d_2024-01.zim",
   "enforced_lang": "fr",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/dwds/info.json
+++ b/dwds/info.json
@@ -6,5 +6,6 @@
   "disable_title": true,
   "disable_external_links": true,
   "about_app_url": "https://www.dwds.de/a/",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/phet/info.json
+++ b/phet/info.json
@@ -6,5 +6,6 @@
   "disable_tabs": true,
   "disable_read_aloud": true,
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/sample_app/info.json
+++ b/sample_app/info.json
@@ -6,5 +6,6 @@
   "ic_launcher": "icon.png",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/tunisie/info.json
+++ b/tunisie/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fr_tunisie-app_maxi_2023-12.zim",
   "enforced_lang": "fr",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/venezuela/info.json
+++ b/venezuela/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_es_venezuela-app_maxi_2023-12.zim",
   "enforced_lang": "es",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimania/info.json
+++ b/wikimania/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://drive.farm.openzim.org/custom%20apps/wikimania/wikimania_en_2025-07.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimed/info.json
+++ b/wikimed/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/mdwiki_en_all-app_maxi_2024-05.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": false
+  "upload_bundle": false,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedar/info.json
+++ b/wikimedar/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_ar_medicine-app_maxi_2023-12.zim",
   "enforced_lang": "ar",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedde/info.json
+++ b/wikimedde/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_de_medicine-app_maxi_2024-05.zim",
   "enforced_lang": "de",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedes/info.json
+++ b/wikimedes/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_es_medicine-app_maxi_2023-12.zim",
   "enforced_lang": "es",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedfa/info.json
+++ b/wikimedfa/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fa_medicine-app_maxi_2023-12.zim",
   "enforced_lang": "fa",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedfr/info.json
+++ b/wikimedfr/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fr_medicine-app_maxi_2024-05.zim",
   "enforced_lang": "fr",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedja/info.json
+++ b/wikimedja/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_ja_medicine-app_maxi_2023-12.zim",
   "enforced_lang": "ja",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedmini/info.json
+++ b/wikimedmini/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/mdwiki_en_all-app_mini_2023-12.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedor/info.json
+++ b/wikimedor/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_or_medicine-app_maxi_2023-12.zim",
   "enforced_lang": "or",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedpt/info.json
+++ b/wikimedpt/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_pt_medicine-app_maxi_2023-12.zim",
   "enforced_lang": "pt",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimeduk/info.json
+++ b/wikimeduk/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_uk_medicine-app_maxi_2023-12.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikimedzh/info.json
+++ b/wikimedzh/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_zh_medicine-app_maxi_2023-12.zim",
   "enforced_lang": "zh",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikispecies/info.json
+++ b/wikispecies/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikispecies_en_all-app_maxi_2023-12.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": false
+  "upload_bundle": false,
+  "kiwix-android_revision": "latest"
 }

--- a/wikivoyage/info.json
+++ b/wikivoyage/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikivoyage_en_all-app_maxi_2024-06.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikivoyagede/info.json
+++ b/wikivoyagede/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/wikivoyage/wikivoyage_de_all_maxi_2024-06.zim",
   "enforced_lang": "de",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wikivoyageeurope/info.json
+++ b/wikivoyageeurope/info.json
@@ -3,5 +3,6 @@
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikivoyage_en_europe-app_maxi_2024-06.zim",
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }

--- a/wiktionaryar/info.json
+++ b/wiktionaryar/info.json
@@ -4,5 +4,6 @@
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
   "upload_bundle": true,
-  "new": false
+  "new": false,
+  "kiwix-android_revision": "latest"
 }

--- a/wpbm/info.json
+++ b/wpbm/info.json
@@ -40,5 +40,6 @@
   "zim_url": "https://download.kiwix.org/zim/wikipedia/wikipedia_bm_all_maxi_2019-10.zim",
   "enforced_lang": "bm",
   "support_url": "https://www.kiwix.org/support",
-  "upload_bundle": true
+  "upload_bundle": true,
+  "kiwix-android_revision": "latest"
 }


### PR DESCRIPTION
Fixes #232 

* Added the `kiwix-android_revision` field to the `info.json` file. If this field is set to `latest` or an `empty` string, the latest commit from the `kiwix-android` main branch will be used to build the application. Otherwise, if a valid commit SHA is provided, the custom app will be built using the codebase from that specific commit.
* Updated the README file to reflect this change.