### PR TITLE
Introduced the `show_search_suggestions_spellchecked` key in the `info.json` file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ important fields are:
   run.
 - `upload_bundle` A boolean value. When set to true, it uploads the bundle to the Play Store,
   Otherwise, it uploads the APK.
+- `show_search_suggestions_spellchecked` A boolean value. When set to `true`, it shows alternative suggestions when the user enters a misspelled search term.
 - `kiwix-android_revision` A specific Git commit SHA (revision ID) of the `kiwix-android` repository to use when building the app.
    - If this field is set to an `empty` string or `latest`, the latest commit from the `main` branch will be used.
    - If this field contains a valid commit SHA, that specific version of the `kiwix-android` code base will be used for the build.

--- a/dwds/info.json
+++ b/dwds/info.json
@@ -8,5 +8,6 @@
   "about_app_url": "https://www.dwds.de/a/",
   "upload_bundle": true,
   "disable_help_menu": true,
+  "show_search_suggestions_spellchecked": true,
   "kiwix-android_revision": "latest"
 }


### PR DESCRIPTION
See https://github.com/kiwix/java-libkiwix/pull/130

* Introduced the `show_search_suggestions_spellchecked` key in the `info.json` file for custom apps. When set to `true`, it displays alternative suggestions when the user enters a misspelled search term.
* Updated the README file to document this new key.
* Enabled this feature by default for the `DWDS` app.