### PR TITLE
Update DWDS Custom App ZIM to v2025-11-18

### DIFF
--- a/dwds/info.json
+++ b/dwds/info.json
@@ -1,6 +1,6 @@
 {
   "app_name": "DWDS",
-  "zim_url": "https://{{DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2025-04-08.zim",
+  "zim_url": "https://{{DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2025-11-18.zim",
   "enforced_lang": "de",
   "disable_read_aloud": true,
   "disable_title": true,


### PR DESCRIPTION
This ZIM file was built using libzim 9.4.0, and includes:

* an update for the DWDS dictionary
* a native dark mode using Dark Reader as bundled JS dependency