### PR TITLE
Update DWDS Custom App ZIM to v2025-11-28

### DIFF
--- a/dwds/info.json
+++ b/dwds/info.json
@@ -1,6 +1,6 @@
 {
   "app_name": "DWDS",
-  "zim_url": "https://{{DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2025-11-20.zim",
+  "zim_url": "https://{{DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2025-11-28.zim",
   "enforced_lang": "de",
   "disable_read_aloud": true,
   "disable_title": true,


### PR DESCRIPTION
https://github.com/openzim/dwds/issues/30#issuecomment-3580416998

Ah, sorry, I misunderstood. The switch in the ZIM file is now gone. I have created a new ZIM file, which will (hopefully) automatically recognise the theme that the user has set in their system or the settings they have made in the app.