### PR TITLE
Using the `venezuela` 2025-10 ZIM file.

### DIFF
--- a/venezuela/info.json
+++ b/venezuela/info.json
@@ -1,9 +1,9 @@
 {
   "app_name": "Enciclopedia de Venezuela",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_es_venezuela_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_es_venezuela-app_maxi_2025-07.zim",
+  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_es_venezuela-app_maxi_2025-10.zim",
   "enforced_lang": "es",
   "support_url": "https://www.kiwix.org/support",
   "upload_bundle": true,
-  "kiwix-android_revision": "ccffb07ae47b3753be501d55cfb8c7c8977cc973"
+  "kiwix-android_revision": "latest"
 }


### PR DESCRIPTION
* Using the `venezuela` 2025-10 ZIM file.
* Used `main` branch of `kiwix-android` for releasing the `venezuela`(Enciclopedia de Venezuela) app.

Parent Issue #256 