### PR TITLE
Using the `tunisie` 2025-10 ZIM file.

### DIFF
--- a/tunisie/info.json
+++ b/tunisie/info.json
@@ -1,9 +1,9 @@
 {
   "app_name": "Encyclopédie de la Tunisie",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_fr_tunisie_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fr_tunisie-app_maxi_2025-07.zim",
+  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fr_tunisie-app_maxi_2025-10.zim",
   "enforced_lang": "fr",
   "support_url": "https://www.kiwix.org/support",
   "upload_bundle": true,
-  "kiwix-android_revision": "ccffb07ae47b3753be501d55cfb8c7c8977cc973"
+  "kiwix-android_revision": "latest"
 }


### PR DESCRIPTION
* Using the `tunisie` 2025-10 ZIM file.
* Used the `main` branch of `kiwix-android` for releasing the `tunisie`(Encyclopédie de la Tunisie) app.