### PR TITLE
Add recipe URL for Wikimed AR `info.json`

### DIFF
--- a/wikimedar/info.json
+++ b/wikimedar/info.json
@@ -1,5 +1,6 @@
 {
   "app_name": "ويكيبيديا الطبية",
+  "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_ar_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_ar_medicine-app_maxi_2025-11.zim",
   "enforced_lang": "ar",
   "support_url": "https://www.kiwix.org/support",


### PR DESCRIPTION
~Fixes # 211~

This is `wikimedar` and the linked issue is for `wiktionaryar`. Wikimed AR app was recently launched on the Play Store.
