### PR TITLE
Deprecated the `AFCONpedia` app.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,6 +70,17 @@ jobs:
             echo "$playstore_json" > kiwix-android/playstore.json
           fi
 
+      - name: Check app is not deprecated
+        run: |
+          cd ${TAG}
+          is_deprecated=$(jq -r '.deprecated // empty' info.json)
+          if [ "$is_deprecated" = "true" ]; then
+            echo "Error: This app is marked as deprecated in info.json. Publishing is not allowed."
+            exit 1
+          else
+            echo "App is not deprecated. Continuing…"
+          fi
+
       - name: Should upload Bundle
         run: |
           cd ${TAG}
@@ -139,6 +150,17 @@ jobs:
 
       - name: Copying custom app configuration into Kiwix Android code base
         run: ./copy_files_to_kiwix_android.sh
+
+      - name: Check app is not deprecated
+        run: |
+          cd ${TAG}
+          is_deprecated=$(jq -r '.deprecated // empty' info.json)
+          if [ "$is_deprecated" = "true" ]; then
+            echo "Error: This app is marked as deprecated in info.json. Publishing is not allowed."
+            exit 1
+          else
+            echo "App is not deprecated. Continuing…"
+          fi
 
       - name: Should upload dummy Bundle
         run: |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ important fields are:
 - `upload_bundle` A boolean value. When set to true, it uploads the bundle to the Play Store,
   Otherwise, it uploads the APK.
 - `show_search_suggestions_spellchecked` A boolean value. When set to `true`, it shows alternative suggestions when the user enters a misspelled search term.
+- `deprecated`, a boolean value, when set to `true`. The app is considered deprecated and will not be uploaded to Google Play by the publishing workflow.
 - `kiwix-android_revision` A specific Git commit SHA (revision ID) of the `kiwix-android` repository to use when building the app.
    - If this field is set to an `empty` string or `latest`, the latest commit from the `main` branch will be used.
    - If this field contains a valid commit SHA, that specific version of the `kiwix-android` code base will be used for the build.

--- a/afconpedia/info.json
+++ b/afconpedia/info.json
@@ -4,5 +4,6 @@
   "enforced_lang": "en",
   "support_url": "https://www.kiwix.org/support",
   "upload_bundle": true,
-  "kiwix-android_revision": "latest"
+  "kiwix-android_revision": "latest",
+  "deprecated": true
 }


### PR DESCRIPTION
Fixes #303 

* Added a new `deprecated` key in the info.json file to mark apps as deprecated. This allows us to deactivate apps without removing them completely.
* Updated the `README` to document the purpose and behavior of this new field.
* Updated the CD pipeline so deprecated apps are no longer published to the Play Store.