### PR TITLE
Updated the donation page URL.

### DIFF
--- a/afconpedia/info.json
+++ b/afconpedia/info.json
@@ -2,7 +2,7 @@
   "app_name": "AFCONpedia",
   "zim_url": "https://drive.farm.openzim.org/custom%20apps/CAN%20App%20-%20English/All%20Articles%20/CANAllArticlesEN-1ed6e94c6348_2024-01.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest",
   "deprecated": true

--- a/bollywood/info.json
+++ b/bollywood/info.json
@@ -3,7 +3,7 @@
   "recipe_url": "https://farm.openzim.org/recipes/wikipedia_en_bollywood_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_en_indian-cinema_maxi_2025-12.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/canpedia/info.json
+++ b/canpedia/info.json
@@ -2,7 +2,7 @@
   "app_name": "Medical Wikipedia",
   "zim_url": "https://drive.farm.openzim.org/custom%20apps/CAN%20App%20-%20French/All%20Articles%20-%20FR/CANAllArticlesFR-4546453e6f9d_2024-01.zim",
   "enforced_lang": "fr",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/phet/info.json
+++ b/phet/info.json
@@ -6,7 +6,7 @@
   "disable_sidebar": true,
   "disable_tabs": true,
   "disable_read_aloud": true,
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/sample_app/info.json
+++ b/sample_app/info.json
@@ -5,7 +5,7 @@
   "embed_zim": false,
   "ic_launcher": "icon.png",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/tunisie/info.json
+++ b/tunisie/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_fr_tunisie_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fr_tunisie-app_maxi_2025-10.zim",
   "enforced_lang": "fr",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/venezuela/info.json
+++ b/venezuela/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_es_venezuela_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_es_venezuela-app_maxi_2025-10.zim",
   "enforced_lang": "es",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimania/info.json
+++ b/wikimania/info.json
@@ -2,7 +2,7 @@
   "app_name": "Wikimania",
   "zim_url": "https://drive.farm.openzim.org/custom%20apps/wikimania/wikimania_en_2025-07.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimed/info.json
+++ b/wikimed/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/mdwiki_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/mdwiki_en_all-app_maxi_2025-11.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": false,
   "kiwix-android_revision": "latest"
 }

--- a/wikimedar/info.json
+++ b/wikimedar/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_ar_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_ar_medicine-app_maxi_2025-11.zim",
   "enforced_lang": "ar",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimedde/info.json
+++ b/wikimedde/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_de_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_de_medicine-app_maxi_2025-12.zim",
   "enforced_lang": "de",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimedes/info.json
+++ b/wikimedes/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_es_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_es_medicine-app_maxi_2025-12.zim",
   "enforced_lang": "es",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimedfa/info.json
+++ b/wikimedfa/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_fa_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fa_medicine-app_maxi_2025-12.zim",
   "enforced_lang": "fa",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimedfr/info.json
+++ b/wikimedfr/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_fr_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fr_medicine-app_maxi_2025-11.zim",
   "enforced_lang": "fr",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimedja/info.json
+++ b/wikimedja/info.json
@@ -2,7 +2,7 @@
   "app_name": "医療ウィキペディア(オフライン)",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_ja_medicine-app_maxi_2025-07.zim",
   "enforced_lang": "ja",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "ccffb07ae47b3753be501d55cfb8c7c8977cc973"
 }

--- a/wikimedmini/info.json
+++ b/wikimedmini/info.json
@@ -3,7 +3,7 @@
   "recipe_url": "https://farm.openzim.org/recipes/mdwiki_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/mdwiki_en_all-app_mini_2025-11.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimedor/info.json
+++ b/wikimedor/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_or_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_or_medicine-app_maxi_2025-11.zim",
   "enforced_lang": "or",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimedpt/info.json
+++ b/wikimedpt/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_pt_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_pt_medicine-app_maxi_2025-12.zim",
   "enforced_lang": "pt",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikimeduk/info.json
+++ b/wikimeduk/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_uk_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_uk_medicine-app_maxi_2025-07.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "ccffb07ae47b3753be501d55cfb8c7c8977cc973"
 }

--- a/wikimedzh/info.json
+++ b/wikimedzh/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_zh_medicine_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_zh_medicine-app_maxi_2025-07.zim",
   "enforced_lang": "zh",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "ccffb07ae47b3753be501d55cfb8c7c8977cc973"
 }

--- a/wikispecies/info.json
+++ b/wikispecies/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikispecies_en_all_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikispecies_en_all-app_maxi_2025-12.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": false,
   "kiwix-android_revision": "latest"
 }

--- a/wikivoyage/info.json
+++ b/wikivoyage/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikivoyage_en_all_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikivoyage_en_all-app_maxi_2025-12.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikivoyagede/info.json
+++ b/wikivoyagede/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikivoyage_de_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikivoyage_de-app_maxi_2025-12.zim",
   "enforced_lang": "de",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wikivoyageeurope/info.json
+++ b/wikivoyageeurope/info.json
@@ -3,7 +3,7 @@
   "zim_recipe": "https://farm.openzim.org/recipes/wikivoyage_en_europe_app",
   "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikivoyage_en_europe-app_maxi_2025-12.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }

--- a/wiktionaryar/info.json
+++ b/wiktionaryar/info.json
@@ -2,7 +2,7 @@
   "app_name": "ويكاموس بدون إنترنت",
   "zim_url": "https://download.kiwix.org/zim/wiktionary/wiktionary_ar_all_maxi_2023-12.zim",
   "enforced_lang": "en",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "new": false,
   "kiwix-android_revision": "latest"

--- a/wpbm/info.json
+++ b/wpbm/info.json
@@ -39,7 +39,7 @@
   "embed_zim": false,
   "zim_url": "https://download.kiwix.org/zim/wikipedia/wikipedia_bm_all_maxi_2019-10.zim",
   "enforced_lang": "bm",
-  "support_url": "https://www.kiwix.org/support",
+  "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,
   "kiwix-android_revision": "latest"
 }


### PR DESCRIPTION
See https://github.com/kiwix/kiwix-android/issues/4843

The old link was not pointing to the correct donation page, so it has now been updated with the proper URL.

Old URL = https://www.kiwix.org/support
New URL = https://donate.kiwix.org/