### PR TITLE
Updated ZIM file URLs according to new server location.

### DIFF
--- a/bollywood/info.json
+++ b/bollywood/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Bollywood Offline",
   "recipe_url": "https://farm.openzim.org/recipes/wikipedia_en_bollywood_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_en_indian-cinema_maxi_2025-12.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_en_indian-cinema_maxi_2026-03.zim",
   "enforced_lang": "en",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/tunisie/info.json
+++ b/tunisie/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Encyclopédie de la Tunisie",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_fr_tunisie_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fr_tunisie-app_maxi_2025-10.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_fr_tunisie-app_maxi_2026-04.zim",
   "enforced_lang": "fr",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/venezuela/info.json
+++ b/venezuela/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Enciclopedia de Venezuela",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_es_venezuela_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_es_venezuela-app_maxi_2025-10.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_es_venezuela-app_maxi_2026-04.zim",
   "enforced_lang": "es",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimed/info.json
+++ b/wikimed/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Medical Wikipedia",
   "zim_recipe": "https://farm.openzim.org/recipes/mdwiki_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/mdwiki_en_all-app_maxi_2025-11.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/mdwiki_en_all-app_mini_2026-02.zim",
   "enforced_lang": "en",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": false,

--- a/wikimedar/info.json
+++ b/wikimedar/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "ويكيبيديا الطبية",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_ar_medicine_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_ar_medicine-app_maxi_2025-11.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_ar_medicine-app_maxi_2026-05.zim",
   "enforced_lang": "ar",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimedde/info.json
+++ b/wikimedde/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Wikipedia Medizin (Offline)",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_de_medicine_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_de_medicine-app_maxi_2025-12.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_de_medicine-app_maxi_2026-03.zim",
   "enforced_lang": "de",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimedes/info.json
+++ b/wikimedes/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Wikipedia Médica (Offline)",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_es_medicine_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_es_medicine-app_maxi_2025-12.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_es_medicine-app_maxi_2026-03.zim",
   "enforced_lang": "es",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimedfa/info.json
+++ b/wikimedfa/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "ویکی‌پدیای پزشکی (آفلاین)",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_fa_medicine_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fa_medicine-app_maxi_2025-12.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_fa_medicine-app_maxi_2026-03.zim",
   "enforced_lang": "fa",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimedfr/info.json
+++ b/wikimedfr/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Wikipédia médicale",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_fr_medicine_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_fr_medicine-app_maxi_2025-11.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_fr_medicine-app_maxi_2026-05.zim",
   "enforced_lang": "fr",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimedja/info.json
+++ b/wikimedja/info.json
@@ -1,6 +1,6 @@
 {
   "app_name": "医療ウィキペディア(オフライン)",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_ja_medicine-app_maxi_2025-07.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_ja_medicine-app_maxi_2026-04.zim",
   "enforced_lang": "ja",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimedmini/info.json
+++ b/wikimedmini/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Offline WikiMed mini",
   "recipe_url": "https://farm.openzim.org/recipes/mdwiki_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/mdwiki_en_all-app_mini_2025-11.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/mdwiki_en_all-app_mini_2026-02.zim",
   "enforced_lang": "en",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimedor/info.json
+++ b/wikimedor/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "ମେଡିକାଲ ଉଇକିପିଡିଆ (ଅଫଲାଇନ)",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_or_medicine_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_or_medicine-app_maxi_2025-11.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_or_medicine-app_maxi_2026-04.zim",
   "enforced_lang": "or",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimedpt/info.json
+++ b/wikimedpt/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Wikipédia Médica (Offline)",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_pt_medicine_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_pt_medicine-app_maxi_2025-12.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_pt_medicine-app_maxi_2026-03.zim",
   "enforced_lang": "pt",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimeduk/info.json
+++ b/wikimeduk/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "ВікіМед",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_uk_medicine_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_uk_medicine-app_maxi_2025-07.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_uk_medicine-app_maxi_2026-04.zim",
   "enforced_lang": "en",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikimedzh/info.json
+++ b/wikimedzh/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "醫學維基百科(離線版)",
   "zim_recipe": "https://farm.openzim.org/recipes/wikipedia_zh_medicine_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikipedia_zh_medicine-app_maxi_2025-07.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikipedia_zh_medicine-app_maxi_2026-05.zim",
   "enforced_lang": "zh",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikispecies/info.json
+++ b/wikispecies/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "WikiSpecies",
   "zim_recipe": "https://farm.openzim.org/recipes/wikispecies_en_all_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikispecies_en_all-app_maxi_2025-12.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikispecies_en_all-app_maxi_2026-03.zim",
   "enforced_lang": "en",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": false,

--- a/wikivoyage/info.json
+++ b/wikivoyage/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Wikivoyage",
   "zim_recipe": "https://farm.openzim.org/recipes/wikivoyage_en_all_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikivoyage_en_all-app_maxi_2025-12.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikivoyage_en_all-app_maxi_2026-03.zim",
   "enforced_lang": "en",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikivoyagede/info.json
+++ b/wikivoyagede/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Wikivoyage auf Deutsch",
   "zim_recipe": "https://farm.openzim.org/recipes/wikivoyage_de_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikivoyage_de-app_maxi_2025-12.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikivoyage_de-app_maxi_2026-03.zim",
   "enforced_lang": "de",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,

--- a/wikivoyageeurope/info.json
+++ b/wikivoyageeurope/info.json
@@ -1,7 +1,7 @@
 {
   "app_name": "Wikivoyage European Travels",
   "zim_recipe": "https://farm.openzim.org/recipes/wikivoyage_en_europe_app",
-  "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/wikivoyage_en_europe-app_maxi_2025-12.zim",
+  "zim_url": "https://staging.download.kiwix.org/zim/branded_apps/wikivoyage_en_europe-app_maxi_2026-03.zim",
   "enforced_lang": "en",
   "support_url": "https://donate.kiwix.org",
   "upload_bundle": true,


### PR DESCRIPTION
Fixes #364 

* Some branded apps use the "regular" ZIMs, not a ZIM custom-made for the app. Such as PhET, Wiktionary AR, and some apps use ZIM files from the drive (AFCONpedia, Canpedia). So we are not updating URLs for those apps.
* Apart from this, we have updated the ZIM URL for all the remaining branded apps.


Previous URL = https://mirror.download.kiwix.org/zim/.hidden/custom_apps/
New URL = https://staging.download.kiwix.org/zim/branded_apps/