### PR TITLE
Updated Java version to 21 in cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Retrieving branded app configuration
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Set tag variable
@@ -113,10 +113,10 @@ jobs:
       - name: Retrieving branded app configuration
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Set tag variable


### PR DESCRIPTION
See  https://github.com/kiwix/kiwix-android/pull/5015

* Now we are starting to use the AGP `9.3.0` which requires Java 21 to run.
* Upgraded setup action to @v5.